### PR TITLE
Clock config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ configuration variables can be used to configure a different clock tree:
       <tt>"PLLRCLK"</tt>,
       <tt>"HSISYS"</tt>
     </td>
-    <td><tt>HSISYS</tt></td>
+    <td><tt>"PLLRCLK"</tt></td>
     <td>
       Specifies the clock source to use for the system clock (SYSCLK).
       <ul>

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ configuration variables can be used to configure a different clock tree:
       <tt>"HSE"</tt>,
       <tt>"HSI16"</tt>
     </td>
-    <td><tt>HSI16</tt></td>
+    <td><tt>"HSI16"</tt></td>
     <td>
       Specifies the clock source to use for the input into the PLL.
       <ul>
@@ -308,7 +308,7 @@ configuration variables can be used to configure a different clock tree:
       <tt>"DIV256"</tt>,
       <tt>"DIV512"</tt>
     </td>
-    <td><tt>DIV1</tt></td>
+    <td><tt>"DIV1"</tt></td>
     <td>
       Specifies the divider to use for the AHB prescaler.
     </td>
@@ -322,7 +322,7 @@ configuration variables can be used to configure a different clock tree:
       <tt>"DIV8"</tt>,
       <tt>"DIV16"</tt>
     </td>
-    <td><tt>DIV1</tt></td>
+    <td><tt>"DIV1"</tt></td>
     <td>
       Specifies the divider to use for the APB prescaler.
     </td>

--- a/stm32g0_src/s-bbbopa.ads
+++ b/stm32g0_src/s-bbbopa.ads
@@ -84,13 +84,27 @@ package System.BB.Board_Parameters is
         when STM32G0xx_Runtime_Config.DIV64  => 64,
         when STM32G0xx_Runtime_Config.DIV128 => 128);
 
-   Main_Clock_Frequency : constant Positive :=
+   SYSCLK_Freq : constant :=
      (case STM32G0xx_Runtime_Config.SYSCLK_Src is
         when STM32G0xx_Runtime_Config.LSE     => LSE_Freq,
         when STM32G0xx_Runtime_Config.LSI     => LSI_Freq,
         when STM32G0xx_Runtime_Config.HSE     => HSE_Freq,
         when STM32G0xx_Runtime_Config.PLLRCLK => PLL_R_Freq,
         when STM32G0xx_Runtime_Config.HSISYS  => HSI_Freq / HSI_Div);
+
+   HCLK_Freq : constant :=
+     SYSCLK_Freq / (case STM32G4xx_Runtime_Config.AHB_Pre is
+                      when STM32G4xx_Runtime_Config.DIV1   => 1,
+                      when STM32G4xx_Runtime_Config.DIV2   => 2,
+                      when STM32G4xx_Runtime_Config.DIV4   => 4,
+                      when STM32G4xx_Runtime_Config.DIV8   => 8,
+                      when STM32G4xx_Runtime_Config.DIV16  => 16,
+                      when STM32G4xx_Runtime_Config.DIV64  => 64,
+                      when STM32G4xx_Runtime_Config.DIV128 => 128,
+                      when STM32G4xx_Runtime_Config.DIV256 => 256,
+                      when STM32G4xx_Runtime_Config.DIV512 => 512);
+
+   Main_Clock_Frequency : constant Positive := HCLK_Freq;
    --  Frequency of the system clock (SYSCLK)
 
 end System.BB.Board_Parameters;

--- a/stm32g0_src/setup_pll.adb
+++ b/stm32g0_src/setup_pll.adb
@@ -104,8 +104,8 @@ procedure Setup_Pll is
            & " 64 MHz");
 
       FLASH_Latency : constant :=
-        (if    Main_Clock_Frequency <= 24_000_000 then 0
-         elsif Main_Clock_Frequency <= 48_000_000 then 1
+        (if    SYSCLK_Freq <= 24_000_000 then 0
+         elsif SYSCLK_Freq <= 48_000_000 then 1
          else  2);
 
       SW_Value : CFGR_SW_Field;

--- a/templates/alire.toml.in
+++ b/templates/alire.toml.in
@@ -125,7 +125,7 @@ PLL_P_Div = { type = "Integer", first = 2, last = 32, default = 2 }
 PLL_Q_Enable = { type = "Boolean", default = true }
 PLL_P_Enable = { type = "Boolean", default = true }
 HSI_Div = { type = "Enum", values = ["DIV1", "DIV2", "DIV4", "DIV8", "DIV16", "DIV32", "DIV64", "DIV128"], default = "DIV1" }
-SYSCLK_Src = { type = "Enum", values = ["LSE", "LSI", "HSE", "PLLRCLK", "HSISYS"], default = "HSISYS" }
+SYSCLK_Src = { type = "Enum", values = ["LSE", "LSI", "HSE", "PLLRCLK", "HSISYS"], default = "PLLRCLK" }
 AHB_Pre = { type = "Enum", values = ["DIV1", "DIV2", "DIV4", "DIV8", "DIV16", "DIV64", "DIV128", "DIV256", "DIV512"], default = "DIV1" }
 APB_Pre = { type = "Enum", values = ["DIV1", "DIV2", "DIV4", "DIV8", "DIV16"], default = "DIV1" }
 


### PR DESCRIPTION
Changes the default SYSCLK source to PLLRCLK from HSI16, and fixes the calculation of the `Main_Clock_Frequency`.